### PR TITLE
Add ensure parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,12 @@ Boolean to control merges of all found instances of repositories in Hiera. This 
 *Parameters*
 ------------
 
+ensure
+------
+Either 'present' or 'absent' Note: not supported for zypprepo
+
+- *Default*: 'present'
+
 repotype
 --------
 Type of repository to configure (yum, zypper, apt)

--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -5,6 +5,7 @@
 define swrepo::repo (
   $repotype,
   $baseurl,
+  $ensure           = 'present',
   $enabled          = '1',
   $autorefresh      = undef,
   $gpgcheck         = undef,
@@ -19,6 +20,8 @@ define swrepo::repo (
   $downcase_baseurl = false,
 ) {
 
+  validate_re($ensure, '^(present)|(absent)$', 'ensure must be either present or absent')
+
   if $downcase_baseurl {
     $baseurl_real = downcase($baseurl)
   } else {
@@ -28,6 +31,7 @@ define swrepo::repo (
   case $repotype {
     'yum': {
       yumrepo { $name:
+        ensure   => $ensure,
         baseurl  => $baseurl_real,
         descr    => $descr,
         enabled  => $enabled,
@@ -61,7 +65,7 @@ define swrepo::repo (
 
   if $repotype =~ /yum|zypper/ and ($gpgkey_source and $gpgkey_keyid) {
     rpmkey { $gpgkey_keyid:
-      ensure => present,
+      ensure => $ensure,
       source => $gpgkey_source,
     }
   }

--- a/spec/defines/repo_spec.rb
+++ b/spec/defines/repo_spec.rb
@@ -22,6 +22,7 @@ describe 'swrepo::repo' do
 
     it {
       should contain_yumrepo('custom-repo').with({
+        'ensure'   => 'present',
         'name'     => 'custom-repo',
         'descr'    => 'custom-repo',
         'baseurl'  => 'http://yum.server.tld/Repo',
@@ -57,6 +58,7 @@ describe 'swrepo::repo' do
 
     it {
       should contain_yumrepo('custom-repo').with({
+        'ensure'   => 'present',
         'name'     => 'custom-repo',
         'descr'    => 'custom-repo',
         'baseurl'  => 'http://yum.server.tld/repo/SubDir',
@@ -99,6 +101,7 @@ describe 'swrepo::repo' do
 
     it {
       should contain_yumrepo('custom-repo').with({
+        'ensure'   => 'present',
         'name'     => 'custom-repo',
         'descr'    => 'custom-repo',
         'baseurl'  => 'http://yum.server.tld/repo/subdir',
@@ -109,6 +112,29 @@ describe 'swrepo::repo' do
         'exclude'  => 'kernel-debug',
         'proxy'    => 'absent',
       })
+    }
+  end
+
+  context 'YUM repo with ensure = absent' do
+    let(:title) { 'custom-repo' }
+    let(:params) {
+      {
+        :ensure        => 'absent',
+        :repotype      => 'yum',
+        :baseurl       => 'http://yum.server.tld/repo/SubDir',
+        :gpgkey_keyid  => '1HEXHEX0',
+        :gpgkey_source => 'http://yum.server.tld/GPGKEY',
+      }
+    }
+    let(:facts) {
+      { :osfamily => 'RedHat', }
+    }
+
+    it {
+      should contain_yumrepo('custom-repo').with_ensure('absent')
+    }
+    it {
+      should contain_rpmkey('1HEXHEX0').with_ensure('absent')
     }
   end
 
@@ -230,4 +256,34 @@ describe 'swrepo::repo' do
       })
     }
   end
+
+  context "with invalid ensure attribute" do
+    let(:title) { 'custom-repo' }
+    let(:params) {{
+      :ensure   => 'stopped',
+      :repotype => 'yum',
+      :baseurl  => 'http://yum.server.tld/Repo',
+    }}
+
+    it 'should fail' do
+      expect {
+        should contain_yumrepo('custom-repo')
+      }.to raise_error(Puppet::Error,/ensure must be either present or absent/)
+    end
+  end
+
+  context "with invalid repotype attribute" do
+    let(:title) { 'custom-repo' }
+    let(:params) {{
+      :repotype => 'rpm',
+      :baseurl  => 'http://yum.server.tld/Repo',
+    }}
+
+    it 'should fail' do
+      expect {
+        should contain_define('swrepo::repo')
+      }.to raise_error(Puppet::Error,/Invalid repotype rpm. Supported repotypes are yum, zypper and apt/)
+    end
+  end
+
 end


### PR DESCRIPTION
The new 'ensure' parameter in swrepo::repo control the ensure attribute
for yumrepo and rpmkey resources (zypprepo resources does not support it)
