### PR TITLE
Prepare 1.0.0 release

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source ENV['GEM_SOURCE'] || 'https://rubygems.org'
 
-if ENV['PUPPET_GEM_VERSION']
-  gem 'puppet', ENV['PUPPET_GEM_VERSION'], :require => false
+if puppetversion = ENV['PUPPET_GEM_VERSION']
+  gem 'puppet', puppetversion, :require => false
 else
   gem 'puppet', :require => false
 end
@@ -19,17 +19,17 @@ gem 'puppet-lint-trailing_comma-check'
 gem 'puppet-lint-undef_in_function-check'
 gem 'puppet-lint-unquoted_string-check'
 gem 'puppet-lint-variable_contains_upcase'
-gem 'rspec-puppet'
+gem 'rspec-puppet', '~> 2.5.0'
 
-gem 'json', '<= 1.8', :require => false                     if RUBY_VERSION < '2.0.0'
-gem 'json_pure', '<= 2.0.1', :require => false              if RUBY_VERSION < '2.0.0'
-gem 'metadata-json-lint', '0.0.11', :require => false       if RUBY_VERSION < '1.9'
-gem 'metadata-json-lint'                                    if RUBY_VERSION >= '1.9'
-gem 'parallel_tests', '<= 2.9.0', :require => false         if RUBY_VERSION < '2.0.0' # [1]
-gem 'puppetlabs_spec_helper', '2.0.2', :require => false    if RUBY_VERSION >= '1.8.7' && RUBY_VERSION < '1.9' # [1]
-gem 'puppetlabs_spec_helper', '>= 2.0.0', :require => false if RUBY_VERSION >= '1.9' # [1]
-gem 'rake', '~> 10.0', :require => false                    if RUBY_VERSION >= '1.8.7' && RUBY_VERSION < '1.9'
-gem 'rspec', '~> 2.0', :require => false                    if RUBY_VERSION >= '1.8.7' && RUBY_VERSION < '1.9'
-gem 'rubocop', :require => false                            if RUBY_VERSION >= '2.0.0'
+gem 'json',                   '<= 1.8'   if RUBY_VERSION < '2.0.0'
+gem 'json_pure',              '<= 2.0.1' if RUBY_VERSION < '2.0.0'
+gem 'metadata-json-lint',     '0.0.11'   if RUBY_VERSION >= '1.8.7' && RUBY_VERSION < '1.9'
+gem 'metadata-json-lint',     '1.0.0'    if RUBY_VERSION >= '1.9' && RUBY_VERSION < '2.0'
+gem 'metadata-json-lint'                 if RUBY_VERSION >= '2.0'
+gem 'parallel_tests',         '<= 2.9.0' if RUBY_VERSION > '1.9.3' # [1]
+gem 'puppetlabs_spec_helper', '2.0.2'    if RUBY_VERSION >= '1.8.7' && RUBY_VERSION < '1.9' # [1]
+gem 'puppetlabs_spec_helper', '>= 2.0.0' if RUBY_VERSION >= '1.9' # [1]
+gem 'rake',                   '~> 10.0'  if RUBY_VERSION >= '1.8.7' && RUBY_VERSION < '1.9'
+gem 'rspec',                  '~> 2.0'   if RUBY_VERSION >= '1.8.7' && RUBY_VERSION < '1.9'
 
-# [1]: Puppetlabs is dropping support for Ruby 1.8.7 in latests releases, pin to last supported version when running on Ruby 1.8.7
+# [1] Puppetlabs is dropping support for Ruby 1.8.7 in latests releases, pin to last supported version when running on Ruby 1.8.7

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 [![Build Status](https://travis-ci.org/jwennerberg/puppet-module-swrepo.png?branch=master)](https://travis-ci.org/jwennerberg/puppet-module-swrepo)
 
-Puppet module for managing software repositories (yum, zypper, apt)
+Puppet module for managing software repositories (yum, zypper)
 
 ===
 
@@ -52,7 +52,7 @@ Boolean to control merges of all found instances of repositories in Hiera. This 
 
 repotype
 --------
-Type of repository to configure (yum, zypper, apt)
+Type of repository to configure (yum, zypper)
 
 - *Default*: N/A
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -8,11 +8,16 @@ class swrepo (
   $hiera_merge  = false,
 ) {
 
+  $hiera_merge_real = str2bool($hiera_merge)
+  validate_bool($hiera_merge_real)
+  if is_string($repotype) == false { fail('swrepo::repotype is not a string') }
+
   case $::osfamily {
     'RedHat': { $repotype_default = 'yum' }
-    'Suse':   { case $::lsbmajdistrelease {
-      '11','12': { $repotype_default = 'zypper' }
-      default:   { fail("Unsupported Suse version ${::lsbmajdistrelease}") }
+    'Suse':   {
+      case $::lsbmajdistrelease {
+        '11','12': { $repotype_default = 'zypper' }
+        default:   { fail("Unsupported Suse version ${::lsbmajdistrelease}") }
       }
     }
     default:  { fail("Supported osfamilies are RedHat and Suse 11/12. Yours identified as <${::osfamily}-${::lsbmajdistrelease}>") }
@@ -26,9 +31,6 @@ class swrepo (
   $defaults = {
     repotype => $repotype_real,
   }
-
-  $hiera_merge_real = str2bool($hiera_merge)
-  validate_bool($hiera_merge_real)
 
   if $repos != undef {
     if $hiera_merge_real == true {

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -15,12 +15,12 @@ class swrepo (
   case $::osfamily {
     'RedHat': { $repotype_default = 'yum' }
     'Suse':   {
-      case $::lsbmajdistrelease {
-        '11','12': { $repotype_default = 'zypper' }
-        default:   { fail("Supported osfamilies are RedHat and Suse 11/12. Yours identified as <${::osfamily}-${::lsbmajdistrelease}>") }
+      case $::operatingsystemrelease {
+        /^(11|12)\./: { $repotype_default = 'zypper' }
+        default:      { fail("Supported osfamilies are RedHat and Suse 11/12. Yours identified as <${::osfamily}-${::operatingsystemrelease}>") }
       }
     }
-    default:  { fail("Supported osfamilies are RedHat and Suse 11/12. Yours identified as <${::osfamily}-${::lsbmajdistrelease}>") }
+    default:  { fail("Supported osfamilies are RedHat and Suse 11/12. Yours identified as <${::osfamily}-${::operatingsystemrelease}>") }
   }
 
   $repotype_real = $repotype ? {

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -17,7 +17,7 @@ class swrepo (
     'Suse':   {
       case $::lsbmajdistrelease {
         '11','12': { $repotype_default = 'zypper' }
-        default:   { fail("Unsupported Suse version ${::lsbmajdistrelease}") }
+        default:   { fail("Supported osfamilies are RedHat and Suse 11/12. Yours identified as <${::osfamily}-${::lsbmajdistrelease}>") }
       }
     }
     default:  { fail("Supported osfamilies are RedHat and Suse 11/12. Yours identified as <${::osfamily}-${::lsbmajdistrelease}>") }

--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -24,7 +24,7 @@ define swrepo::repo (
   validate_re($baseurl,  '^https?:\/\/[\S]+$', 'swrepo::repo::baseurl is not an URL.')
 
   if is_string($repotype) == false { fail('swrepo::repo::repotype is not a string.') }
-  validate_re($repotype, '^(yum|zypper|apt)$', 'swrepo::repo::repotype is invalid. Supported values are yum, apt, and zypper.')
+  validate_re($repotype, '^(yum|zypper)$', 'swrepo::repo::repotype is invalid. Supported values are yum and zypper.')
 
   if $autorefresh == undef {
     $autorefresh_num = undef
@@ -113,9 +113,6 @@ define swrepo::repo (
         type         => $type,
         autorefresh  => $autorefresh_num,
       }
-    }
-    'apt': {
-      notice('apt support coming')
     }
     default: {
       fail("Invalid repotype ${repotype}. Supported repotypes are yum, zypper and apt.")

--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -3,37 +3,100 @@
 # This define manages a repo instance
 #
 define swrepo::repo (
-  $repotype,
   $baseurl,
-  $enabled          = '1',
+  $repotype,
   $autorefresh      = undef,
+  $descr            = undef,
+  $downcase_baseurl = false,
+  $enabled          = true,
+  $exclude          = undef,
   $gpgcheck         = undef,
   $gpgkey_keyid     = undef,
   $gpgkey_source    = undef,
-  $priority         = undef,
   $keeppackages     = undef,
-  $type             = undef,
-  $descr            = undef,
-  $exclude          = undef,
+  $priority         = undef,
   $proxy            = undef,
-  $downcase_baseurl = false,
+  $type             = undef,
 ) {
 
-  if $downcase_baseurl {
+  # variable validations
+  if is_string($baseurl) == false { fail('swrepo::repo::baseurl is not a string.') }
+  validate_re($baseurl,  '^https?:\/\/[\S]+$', 'swrepo::repo::baseurl is not an URL.')
+
+  if is_string($repotype) == false { fail('swrepo::repo::repotype is not a string.') }
+  validate_re($repotype, '^(yum|zypper|apt)$', 'swrepo::repo::repotype is invalid. Supported values are yum, apt, and zypper.')
+
+  if $autorefresh == undef {
+    $autorefresh_num = undef
+  } else {
+    $autorefresh_num = bool2num(str2bool("${autorefresh}")) # lint:ignore:only_variable_string
+  }
+
+  if is_string($descr) == false { fail('swrepo::repo::descr is not a string.') }
+
+  if str2bool("${downcase_baseurl}") { # lint:ignore:only_variable_string
     $baseurl_real = downcase($baseurl)
   } else {
     $baseurl_real = $baseurl
   }
 
+  $enabled_num = bool2num(str2bool("${enabled}")) # lint:ignore:only_variable_string
+
+  if $exclude != undef {
+    if is_string($exclude) == false { fail('swrepo::repo::exclude is not a string.') }
+  }
+
+  if $gpgcheck == undef {
+    $gpgcheck_num = undef
+  } else {
+    $gpgcheck_num = bool2num(str2bool("${gpgcheck}")) # lint:ignore:only_variable_string
+  }
+
+  if $gpgkey_keyid != undef {
+    if is_string($gpgkey_keyid) == false { fail('swrepo::repo::gpgkey_keyid is not a string.') }
+  }
+
+  if $gpgkey_source != undef {
+    if is_string($gpgkey_source) == false { fail('swrepo::repo::gpgkey_source is not a string.') }
+    validate_re($gpgkey_source, '^https?:\/\/[\S]+$', 'swrepo::repo::gpgkey_source is not an URL.')
+  }
+
+  if $keeppackages == undef {
+    $keeppackages_num = undef
+  } else {
+    $keeppackages_num = bool2num(str2bool("${keeppackages}")) # lint:ignore:only_variable_string
+  }
+
+  if $priority == undef {
+    $priority_num = undef
+  } else {
+    case type3x($priority) {
+      'integer': { $priority_num = 0 + $priority } # convert stringified to number
+      default:   { fail('swrepo::repo::priority is not an integer.') }
+    }
+    validate_integer($priority_num, 99, 1)
+  }
+
+  if $proxy != undef {
+    if is_string($proxy) == false { fail('swrepo::repo::proxy is not a string.') }
+    validate_re($proxy, '^https?:\/\/[\S]+$', 'swrepo::repo::proxy is not an URL.')
+  }
+
+  if $type != undef {
+    if is_string($type) == false { fail('swrepo::repo::type is not a string.') }
+    validate_re($type, '^(yum|yast2|rpm-md|plaindir)$', 'swrepo::repo::type is invalid. Supported values are yum, yast2, rpm-md, and plaindir.')
+  }
+
+  # functionality
   case $repotype {
     'yum': {
       yumrepo { $name:
         baseurl  => $baseurl_real,
         descr    => $descr,
-        enabled  => $enabled,
-        gpgcheck => $gpgcheck,
+        enabled  => $enabled_num,
+        gpgcheck => $gpgcheck_num,
         gpgkey   => $gpgkey_source,
-        priority => $priority,
+        priority => $priority_num,
         exclude  => $exclude,
         proxy    => $proxy,
       }
@@ -42,13 +105,13 @@ define swrepo::repo (
       zypprepo { $name:
         baseurl      => $baseurl_real,
         descr        => $descr,
-        enabled      => $enabled,
-        gpgcheck     => $gpgcheck,
+        enabled      => $enabled_num,
+        gpgcheck     => $gpgcheck_num,
         gpgkey       => $gpgkey_source,
-        priority     => $priority,
-        keeppackages => $keeppackages,
+        priority     => $priority_num,
+        keeppackages => $keeppackages_num,
         type         => $type,
-        autorefresh  => $autorefresh,
+        autorefresh  => $autorefresh_num,
       }
     }
     'apt': {
@@ -69,6 +132,4 @@ define swrepo::repo (
       source => $gpgkey_source,
     }
   }
-
-
 }

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -128,7 +128,7 @@ describe 'swrepo' do
     validations = {
       'boolean' => {
         :name    => %w[hiera_merge],
-        :valid   => [true, false, 'true', 'false'],
+        :valid   => [true, 'false'],
         :invalid => ['string', %w[array], { 'ha' => 'sh' }, 3, 2.42, nil],
         :message => 'str2bool',
       },
@@ -141,7 +141,7 @@ describe 'swrepo' do
       'string' => {
         :name    => %w[repotype],
         :valid   => %w[string],
-        :invalid => [], # no type validation yet, should fail on [%w[array], { 'ha' => 'sh' }, 3, 2.42, true],
+        :invalid => [%w[array], { 'ha' => 'sh' }, 3, 2.42, true],
         :message => 'is not a string',
       },
     }

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -2,14 +2,14 @@ require 'spec_helper'
 describe 'swrepo' do
 
   supported_os_families = {
-    'RedHat'  => { :os => 'RedHat',  :lsbmajdist => '7',  :repotype => 'yum' },
-    'Suse-11' => { :os => 'Suse',    :lsbmajdist => '11', :repotype => 'zypper' },
-    'Suse-12' => { :os => 'Suse',    :lsbmajdist => '12', :repotype => 'zypper' },
+    'RedHat'  => { :os => 'RedHat',  :osrelease => '7.4',  :repotype => 'yum' },
+    'Suse-11' => { :os => 'Suse',    :osrelease => '11.1', :repotype => 'zypper' },
+    'Suse-12' => { :os => 'Suse',    :osrelease => '12.2', :repotype => 'zypper' },
   }
 
   unsupported_os_families = {
-    'Suse-10' => { :os => 'Suse',    :lsbmajdist => '10', :repotype => nil },
-    'Unknown' => { :os => 'Unknown', :lsbmajdist => '3',  :repotype => nil },
+    'Suse-10' => { :os => 'Suse',    :osrelease => '10.0', :repotype => nil },
+    'Unknown' => { :os => 'Unknown', :osrelease => '2.42', :repotype => nil },
   }
 
   repos_hash = {
@@ -34,8 +34,8 @@ describe 'swrepo' do
         context "with repos set to a valid hash on supported #{os}" do
           let(:facts) do
             {
-              :osfamily          => facts[:os],
-              :lsbmajdistrelease => facts[:lsbmajdist],
+              :osfamily               => facts[:os],
+              :operatingsystemrelease => facts[:osrelease],
             }
             end
           let(:params) { { :repos => repos_hash}.merge({ :repotype => repotype }) }
@@ -53,8 +53,8 @@ describe 'swrepo' do
     describe "when repos is set to a valid hash on supported #{os}" do
       let(:facts) do
         {
-          :osfamily          => facts[:os],
-          :lsbmajdistrelease => facts[:lsbmajdist],
+          :osfamily               => facts[:os],
+          :operatingsystemrelease => facts[:osrelease],
         }
       end
       let(:params) { { :repos => repos_hash } }
@@ -113,8 +113,8 @@ describe 'swrepo' do
     describe "when running on unsupported #{os}" do
       let(:facts) do
         {
-          :osfamily          => facts[:os],
-          :lsbmajdistrelease => facts[:lsbmajdist],
+          :osfamily               => facts[:os],
+          :operatingsystemrelease => facts[:osrelease],
         }
       end
       it 'should fail' do

--- a/spec/defines/repo_spec.rb
+++ b/spec/defines/repo_spec.rb
@@ -303,7 +303,7 @@ describe 'swrepo::repo' do
       },
       'regex for repotype' => {
         :name    => %w[repotype],
-        :valid   => %w[apt yum zypper],
+        :valid   => %w[yum zypper],
         :invalid => ['string', %w[array], { 'ha' => 'sh' }, 3, 2.42, true, nil],
         :message => '(is not a string|repotype is invalid)',
       },


### PR DESCRIPTION
This PR should prepare the module for a 1.0.0 release.
- full parameter validation
- full spec tests

I have changed boolean like parameters to become real booleans instead of strings. At it's current state the code features backward compatibility for stringified booleans. That support should be removed again after a grace period (maybe as 0.99.0 or 1.0.0-pre) to allow easier migrations.
